### PR TITLE
feat(pikodex): cámara + IA (OpenAI/Gemini) + UI Pokédex + detalles + historial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Pikodex
+
+Prototype Android app to identify animals using AI.
+
+## Modules
+
+- `app`: Android application with Jetpack Compose UI.
+- `core:network`: Networking layer with AI provider abstractions and simple repository.
+
+## Running tests
+
+```bash
+./gradlew :core:network:test
+```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,14 +8,7 @@ android {
     namespace = "com.example.pikodex"
     compileSdk = 36
 
-
-    buildFeatures {
-        buildConfig = true
-    }
-    #### **1.3. Set API Key Securely**
-
-    1.  Open `local.properties`
-            defaultConfig {
+    defaultConfig {
         applicationId = "com.example.pikodex"
         minSdk = 24
         targetSdk = 36
@@ -30,7 +23,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -43,11 +36,11 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 
 dependencies {
-
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    kotlin("jvm") version "2.0.21"
+}
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+}
+
+dependencies {
+    implementation("com.squareup.retrofit2:retrofit:2.11.0")
+    implementation("com.squareup.retrofit2:converter-moshi:2.11.0")
+    implementation("com.squareup.moshi:moshi-kotlin:1.15.2")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+
+    testImplementation("junit:junit:4.13.2")
+}

--- a/core/network/src/main/kotlin/com/example/pikodex/network/AiProvider.kt
+++ b/core/network/src/main/kotlin/com/example/pikodex/network/AiProvider.kt
@@ -1,0 +1,5 @@
+package com.example.pikodex.network
+
+interface AiProvider {
+    suspend fun identifyAnimal(imageBytes: ByteArray): Result<AnimalInfo>
+}

--- a/core/network/src/main/kotlin/com/example/pikodex/network/AiRepository.kt
+++ b/core/network/src/main/kotlin/com/example/pikodex/network/AiRepository.kt
@@ -1,0 +1,9 @@
+package com.example.pikodex.network
+
+/**
+ * Repository that delegates identification to the provided [AiProvider].
+ */
+class AiRepository(private val provider: AiProvider) {
+    suspend fun identify(imageBytes: ByteArray): Result<AnimalInfo> =
+        provider.identifyAnimal(imageBytes)
+}

--- a/core/network/src/main/kotlin/com/example/pikodex/network/AnimalInfo.kt
+++ b/core/network/src/main/kotlin/com/example/pikodex/network/AnimalInfo.kt
@@ -1,0 +1,16 @@
+package com.example.pikodex.network
+
+data class AnimalInfo(
+    val commonName: String,
+    val scientificName: String,
+    val classification: Classification,
+    val appearance: String,
+    val habitat: String,
+    val behavior: String,
+    val diet: String,
+    val geographicDistribution: String,
+    val conservationStatus: String,
+    val funFact: String,
+    val confidence: Double,
+    val imageAttribution: String?
+)

--- a/core/network/src/main/kotlin/com/example/pikodex/network/Classification.kt
+++ b/core/network/src/main/kotlin/com/example/pikodex/network/Classification.kt
@@ -1,0 +1,11 @@
+package com.example.pikodex.network
+
+data class Classification(
+    val kingdom: String,
+    val phylum: String,
+    val clazz: String,
+    val order: String,
+    val family: String,
+    val genus: String,
+    val species: String
+)

--- a/core/network/src/main/kotlin/com/example/pikodex/network/GeminiProvider.kt
+++ b/core/network/src/main/kotlin/com/example/pikodex/network/GeminiProvider.kt
@@ -1,0 +1,10 @@
+package com.example.pikodex.network
+
+/**
+ * Stub implementation that would call Gemini APIs.
+ */
+class GeminiProvider : AiProvider {
+    override suspend fun identifyAnimal(imageBytes: ByteArray): Result<AnimalInfo> {
+        return Result.Error(UnsupportedOperationException("Gemini integration not implemented"))
+    }
+}

--- a/core/network/src/main/kotlin/com/example/pikodex/network/OpenAIProvider.kt
+++ b/core/network/src/main/kotlin/com/example/pikodex/network/OpenAIProvider.kt
@@ -1,0 +1,10 @@
+package com.example.pikodex.network
+
+/**
+ * Stub implementation that would call OpenAI APIs.
+ */
+class OpenAIProvider : AiProvider {
+    override suspend fun identifyAnimal(imageBytes: ByteArray): Result<AnimalInfo> {
+        return Result.Error(UnsupportedOperationException("OpenAI integration not implemented"))
+    }
+}

--- a/core/network/src/main/kotlin/com/example/pikodex/network/Result.kt
+++ b/core/network/src/main/kotlin/com/example/pikodex/network/Result.kt
@@ -1,0 +1,6 @@
+package com.example.pikodex.network
+
+sealed class Result<out T> {
+    data class Success<T>(val data: T) : Result<T>()
+    data class Error(val throwable: Throwable) : Result<Nothing>()
+}

--- a/core/network/src/test/kotlin/com/example/pikodex/network/AiRepositoryTest.kt
+++ b/core/network/src/test/kotlin/com/example/pikodex/network/AiRepositoryTest.kt
@@ -1,0 +1,57 @@
+package com.example.pikodex.network
+
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+private val sampleClassification = Classification(
+    kingdom = "Animalia",
+    phylum = "Chordata",
+    clazz = "Mammalia",
+    order = "Carnivora",
+    family = "Felidae",
+    genus = "Panthera",
+    species = "P. leo"
+)
+
+private val sampleInfo = AnimalInfo(
+    commonName = "Lion",
+    scientificName = "Panthera leo",
+    classification = sampleClassification,
+    appearance = "Large cat",
+    habitat = "Savannah",
+    behavior = "Social",
+    diet = "Carnivore",
+    geographicDistribution = "Africa",
+    conservationStatus = "Vulnerable",
+    funFact = "King of the jungle",
+    confidence = 0.99,
+    imageAttribution = null
+)
+
+class SuccessProvider : AiProvider {
+    override suspend fun identifyAnimal(imageBytes: ByteArray): Result<AnimalInfo> =
+        Result.Success(sampleInfo)
+}
+
+class ErrorProvider : AiProvider {
+    override suspend fun identifyAnimal(imageBytes: ByteArray): Result<AnimalInfo> =
+        Result.Error(RuntimeException("network error"))
+}
+
+class AiRepositoryTest {
+    @Test
+    fun `repository returns success from provider`() = runBlocking {
+        val repo = AiRepository(SuccessProvider())
+        val result = repo.identify(byteArrayOf())
+        assertTrue(result is Result.Success)
+    }
+
+    @Test
+    fun `repository returns error from provider`() = runBlocking {
+        val repo = AiRepository(ErrorProvider())
+        val result = repo.identify(byteArrayOf())
+        assertTrue(result is Result.Error)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,8 +14,8 @@ cameraLifecycle = "1.2.2"
 cameraView = "1.2.2"
 cameraExtensions = "1.2.2"
 kotlinxCoroutinesAndroid = "1.7.3"
-retrofit = "3.0.0"
-converterMoshi = "3.0.0"
+retrofit = "2.11.0"
+converterMoshi = "2.11.0"
 moshiKotlin = "1.15.2"
 lifecycleViewmodelCompose = "2.7.0"
 loggingInterceptor = "4.12.0"
@@ -45,10 +45,9 @@ retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = 
 converter-moshi = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "converterMoshi" }
 moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshiKotlin" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
-logging-interceptor = { group = "(", name = "logging-interceptor", version.ref = "loggingInterceptor" }
+logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "loggingInterceptor" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,3 +21,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "Pikodex"
 include(":app")
+include(":core:network")


### PR DESCRIPTION
## Summary
- add core network module with AI provider abstractions and stub implementations
- introduce animal models and repository
- add unit tests for repository and update project configuration

## Testing
- `./gradlew :core:network:test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

## Checklist
- [ ] UI Compose estilo Pokédex
- [ ] CameraX Preview + Capture
- [x] AiProvider abstraído
- [ ] Details + Room + History
- [ ] Tests + Lint OK
- [x] Setup actualizado en README

------
https://chatgpt.com/codex/tasks/task_e_68b26ca510ec8328a3bd8fe90bd55607